### PR TITLE
ORMLite test should lazy load foreign relationships for fairer comparison

### DIFF
--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/MainActivity.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/MainActivity.java
@@ -73,8 +73,7 @@ public class MainActivity extends FragmentActivity {
     }
 
     public void showGlobalResults(View v) {
-        ResultDialog dialog = ResultDialog.newInstance(R.string.results_title,
-                mResults);
+        ResultDialog dialog = ResultDialog.newInstance(R.string.results_title, mResults);
         FragmentTransaction tx = getSupportFragmentManager().beginTransaction();
         tx.add(dialog, ResultDialog.class.getSimpleName());
         tx.commit();
@@ -200,7 +199,7 @@ public class MainActivity extends FragmentActivity {
 
     public static class ResultDialog extends DialogFragment {
 
-        private static String TITLE_RES_ID = "tittle_res_id";
+        private static String TITLE_RES_ID = "title_res_id";
 
         private static String MESSAGE = "message";
 
@@ -220,8 +219,7 @@ public class MainActivity extends FragmentActivity {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             return builder
                     .setTitle(getArguments().getInt(TITLE_RES_ID))
-                    .setMessage(
-                            Html.fromHtml(getArguments().getString(MESSAGE)))
+                    .setMessage(Html.fromHtml(getArguments().getString(MESSAGE)))
                     .create();
         }
     }

--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/Message.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/Message.java
@@ -56,7 +56,7 @@ public class Message {
     @DatabaseField(columnName = CHANNEL_ID, canBeNull = false, dataType = DataType.LONG)
     private long mChannelId;
 
-    @ForeignCollectionField(eager = true, columnName = READERS)
+    @ForeignCollectionField(eager = false, columnName = READERS)
     private ForeignCollection<User> mReaders;
 
     private static Dao<Message, Long> sDao;

--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/User.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/User.java
@@ -13,7 +13,7 @@ public class User extends Contact {
 
     private static Dao<User, Long> sDao;
 
-    @DatabaseField(columnName = "message_id", foreign = true, foreignAutoRefresh = true)
+    @DatabaseField(columnName = "message_id", foreign = true, foreignAutoRefresh = false)
     private Message mMessage;
 
     public User() {

--- a/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/config/DBConfigUtil.java
+++ b/ORM-Benchmark/src/main/java/com/littleinc/orm_benchmark/ormlite/config/DBConfigUtil.java
@@ -6,17 +6,20 @@ import com.littleinc.orm_benchmark.ormlite.User;
 
 public class DBConfigUtil extends OrmLiteConfigUtil {
 
-    private static final Class<?>[] sClasses = new Class[] { User.class,
-            Message.class };
+    private static final Class<?>[] sClasses = new Class[] { User.class, Message.class };
 
     /**
-     * You must run this method to regenerate res/raw/ormlite_config.txt 
+     * To make this work in Android Studio, you may need to update your
+     * Run Configuration as explained here:
+     *   http://stackoverflow.com/a/17332546
+     *
+     * You must run this method to regenerate res/raw/ormlite_config.txt
      * any time the database definitions are updated.
-     * 
+     *
      * You need to update the Run Configuration for this class to set a
      * JRE, and remove the Android bootstrap entry. Instructions here:
      * http://ormlite.com/javadoc/ormlite-core/doc-files/ormlite_4.html
-     * 
+     *
      * If you are adding a new ORM managed class you must add it to the
      * array of classes above.
      */

--- a/ORM-Benchmark/src/main/res/raw/ormlite_config.txt
+++ b/ORM-Benchmark/src/main/res/raw/ormlite_config.txt
@@ -1,5 +1,5 @@
 #
-# generated on 2013/12/11 11:26:52
+# generated on 2015/05/13 11:14:27
 #
 # --table-start--
 dataClass=com.littleinc.orm_benchmark.ormlite.User
@@ -9,7 +9,6 @@ tableName=user
 fieldName=mMessage
 columnName=message_id
 foreign=true
-foreignAutoRefresh=true
 # --field-end--
 # --field-start--
 fieldName=mId
@@ -82,7 +81,6 @@ canBeNull=false
 fieldName=mReaders
 columnName=readers
 foreignCollection=true
-foreignCollectionEager=true
 foreignCollectionColumnName=readers
 # --field-end--
 # --table-fields-end--

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Task READ_DATA
 M RAW - Avg: 803
 RAW - Avg: 808
 
-M ORMLite - Avg: 14275
-ORMLite - Avg: 15729
+M ORMLite - Avg: 1656
+ORMLite - Avg: 1729
 
 M GreenDAO - Avg: 1183
 GreenDAO - Avg: 1186


### PR DESCRIPTION
This change is based on this comment:
http://stackoverflow.com/questions/20079568/orm-performance-is-greendao-faster-than-ormlite/20724107#comment36763167_20724107

FTR, when generating the ORMLite config file in Android Studio, you may need to follow these instructions:
http://stackoverflow.com/a/17332546
